### PR TITLE
Support Latin American Spanish

### DIFF
--- a/src/extract/gen_common.rs
+++ b/src/extract/gen_common.rs
@@ -109,7 +109,7 @@ pub fn right_aside() -> Box<aside<String>> {
     </p>
     <ul class="menu-list">
     {
-        (0..32).filter_map(|i| {
+        (0..33).filter_map(|i| {
             let (language_name, language_code) = LANGUAGE_MAP[i]?;
             let id_string = format!("mh-lang-menu-{language_code}");
             Some(html!{<li><button type="button" class="mh-lang-menu" id={id_string.as_str()}> {

--- a/src/extract/gen_website.rs
+++ b/src/extract/gen_website.rs
@@ -25,7 +25,7 @@ pub struct WebsiteConfig {
     pub origin: Option<String>, // e.g. https://mhrice.info
 }
 
-pub const LANGUAGE_MAP: [Option<(&str, &str)>; 32] = [
+pub const LANGUAGE_MAP: [Option<(&str, &str)>; 33] = [
     Some(("Japanese", "ja")),
     Some(("English", "en")),
     Some(("French", "fr")),
@@ -58,6 +58,7 @@ pub const LANGUAGE_MAP: [Option<(&str, &str)>; 32] = [
     None,
     None,
     None,
+    Some(("Latin American Spanish", "es-419")),
 ];
 
 pub fn head_common(
@@ -468,7 +469,7 @@ where
     RefF: Fn(&str) -> Option<&'r MsgEntry> + Clone,
 {
     html!(<span> {
-        (0..32).filter_map(|i|{
+        (0..33).filter_map(|i|{
             let class_string = if i == 1 {
                 "mh-lang lang-default"
             } else {

--- a/src/pak.rs
+++ b/src/pak.rs
@@ -29,7 +29,7 @@ static PAK_SUB_KEY_EXP: Lazy<Vec<u8>> = Lazy::new(|| {
 const LANGUAGE_LIST: &[&str] = &[
     "", "Ja", "En", "Fr", "It", "De", "Es", "Ru", "Pl", "Nl", "Pt", "PtBR", "Ko", "ZhTW", "ZhCN",
     "Fi", "Sv", "Da", "No", "Cs", "Hu", "Sk", "Ar", "Tr", "Bu", "Gr", "Ro", "Th", "Uk", "Vi", "Id",
-    "Fc", "Hi",
+    "Fc", "Hi", "Es419"
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]


### PR DESCRIPTION
New language Latin American Spanish was supported starting from [15.0.0](https://www.monsterhunter.com/rise-sunbreak/update/en-us/ver15_00_00.html)

This PR:
* Add Latin American Spanish content to mhrice website
* Add `Es419` file suffix to support Latin American Spanish specific resources